### PR TITLE
Fix macOS builds for stopmotion with webcams

### DIFF
--- a/ci-scripts/osx/travis-build.sh
+++ b/ci-scripts/osx/travis-build.sh
@@ -5,6 +5,7 @@ popd
 cd toonz && mkdir build && cd build
 QTVERSION=`ls /usr/local/Cellar/qt`
 echo "QT Version detected: $QTVERSION"
+export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/jpeg-turbo/lib/pkgconfig"
 cmake ../sources \
       -DQT_PATH=/usr/local/Cellar/qt/$QTVERSION/lib/ \
       -DTIFF_INCLUDE_DIR=../../thirdparty/tiff-4.0.3/libtiff/ \

--- a/ci-scripts/osx/travis-install.sh
+++ b/ci-scripts/osx/travis-install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 brew update
-brew install glew lz4 lzo libusb libmypaint
+brew install glew lz4 lzo libusb libmypaint opencv jpeg-turbo
 brew tap tcr/tcr
 brew install clang-format
 # from Homebrew 1.6.0 the old formula for obtaining Qt5.9.2 becomes invalid.

--- a/doc/how_to_build_macosx.md
+++ b/doc/how_to_build_macosx.md
@@ -9,6 +9,8 @@
 - cmake (3.2.2 or later)
 - Qt (5.9.2 or later)
 - boost (1.55.0 or later)
+- OpenCV
+- Jpeg-turbo
 
 ## Building on macOS
 ### Download boost from https://boost.org
@@ -39,7 +41,7 @@ $ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/
 
 In a Terminal window, execute the following statements:
 ```
-$ brew install glew lz4 libjpeg libpng lzo pkg-config libusb cmake git-lfs libmypaint qt
+$ brew install glew lz4 libjpeg libpng lzo pkg-config libusb cmake git-lfs libmypaint qt opencv jpeg-turbo
 $ git lfs install
 ```
 
@@ -68,7 +70,7 @@ $ tar xvjf boost_1_72_0.tar.bz2
 $ cd ../lzo
 $ cp -r 2.03/include/lzo driver
 $ cd ../tiff-4.0.3
-$ ./configure && make
+$ ./configure --disable-lzma && make
 ```
 
 ### Configure build for QT version
@@ -85,6 +87,7 @@ If you downloaded the QT installer and installed to `/Users/yourlogin/Qt`, your 
 $ cd ~/Documents/opentoonz/toonz
 $ mkdir build
 $ cd build
+$ export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/jpeg-turbo/lib/pkgconfig"
 ```
 
 2. Set up build environment

--- a/toonz/sources/CMakeLists.txt
+++ b/toonz/sources/CMakeLists.txt
@@ -1,4 +1,4 @@
-﻿cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 2.8.11)
 
 set(CMAKE_BUILD_TYPE_INIT Release)
 
@@ -402,7 +402,11 @@ elseif(BUILD_ENV_APPLE)
     message("LZO:" ${LZO_INCLUDE_DIR})
 
     pkg_check_modules(MYPAINT_LIB REQUIRED libmypaint)
-    set(TURBOJPEG_LIB ${SDKROOT}/libjpeg-turbo64/lib/turbojpeg.lib)
+
+    pkg_check_modules(TURBOJPEG REQUIRED libturbojpeg)
+    find_library(TURBOJPEG_LIB turbojpeg ${TURBOJPEG_LIBRARY_DIRS})
+    message("**************** turbojpeg lib:" ${TURBOJPEG_LIB})
+
     if (WITH_CANON)
         set(CANON_LIB ${SDKROOT}/canon/library/EDSDK.lib)
     endif()

--- a/toonz/sources/stopmotion/stopmotion.cpp
+++ b/toonz/sources/stopmotion/stopmotion.cpp
@@ -222,10 +222,10 @@ bool getRasterLevelSize(TXshLevel *level, TDimension &dim) {
 //=============================================================================
 //=============================================================================
 
-#if WITH_CANON
-
 JpgConverter::JpgConverter() {}
 JpgConverter::~JpgConverter() {}
+
+#if WITH_CANON
 
 void JpgConverter::setStream(EdsStreamRef stream) { m_stream = stream; }
 
@@ -2610,6 +2610,7 @@ bool StopMotion::translateIndex(int index) {
 //-----------------------------------------------------------------
 
 bool StopMotion::initWebcam(int index) {
+#if WIN32
   if (!m_useDirectShow) {
     // the webcam order obtained from Qt isn't always the same order as
     // the one obtained from OpenCV without DirectShow
@@ -2622,7 +2623,9 @@ bool StopMotion::initWebcam(int index) {
   if (m_cvWebcam.isOpened() == false) {
     return false;
   }
-
+#else
+    m_cvWebcam.open(index);
+#endif
   return true;
 }
 

--- a/toonz/sources/stopmotion/stopmotioncontroller.cpp
+++ b/toonz/sources/stopmotion/stopmotioncontroller.cpp
@@ -1386,12 +1386,14 @@ void StopMotionController::onNewCameraSelected(int index, bool useWebcam) {
     m_resolutionCombo->show();
     m_resolutionCombo->setEnabled(true);
     m_resolutionLabel->show();
-    m_captureFilterSettingsBtn->show();
+    if (m_captureFilterSettingsBtn)
+        m_captureFilterSettingsBtn->show();
     m_cameraStatusLabel->hide();
   } else {
     m_resolutionCombo->hide();
     m_resolutionLabel->hide();
-    m_captureFilterSettingsBtn->hide();
+    if (m_captureFilterSettingsBtn)
+        m_captureFilterSettingsBtn->hide();
     m_cameraStatusLabel->show();
     if (m_tabBar->tabText(1) == tr("Options")) {
       m_tabBar->insertTab(1, tr("Settings"));

--- a/toonz/sources/toonz/CMakeLists.txt
+++ b/toonz/sources/toonz/CMakeLists.txt
@@ -416,7 +416,10 @@ if (WITH_CANON)
 endif()
 
 if(BUILD_ENV_APPLE)
-    include_directories(../../sources/mousedragfilter)
+    include_directories(
+       ../../sources/mousedragfilter
+       ${TURBOJPEG_INCLUDE_DIRS}
+    )
 endif()
 
 

--- a/toonz/sources/toonz/penciltestpopup.cpp
+++ b/toonz/sources/toonz/penciltestpopup.cpp
@@ -1282,7 +1282,11 @@ PencilTestPopup::PencilTestPopup()
   m_captureButton          = new QPushButton(tr("Capture\n[Return key]"), this);
   QPushButton* closeButton = new QPushButton(tr("Close"), this);
 
+#if WIN32
   m_captureFilterSettingsBtn = new QPushButton(this);
+#else
+  m_captureFilterSettingsBtn = 0;
+#endif
 
   QPushButton* subfolderButton = new QPushButton(tr("Subfolder"), this);
 
@@ -1341,11 +1345,13 @@ PencilTestPopup::PencilTestPopup()
   m_captureButton->setIcon(style.standardIcon(QStyle::SP_DialogOkButton));
   m_captureButton->setIconSize(QSize(30, 30));
 
-  m_captureFilterSettingsBtn->setObjectName("GearButton");
-  m_captureFilterSettingsBtn->setFixedSize(23, 23);
-  m_captureFilterSettingsBtn->setIconSize(QSize(15, 15));
-  m_captureFilterSettingsBtn->setToolTip(tr("Options"));
-  m_captureFilterSettingsBtn->setMenu(createOptionsMenu());
+  if(m_captureFilterSettingsBtn) {
+     m_captureFilterSettingsBtn->setObjectName("GearButton");
+     m_captureFilterSettingsBtn->setFixedSize(23, 23);
+     m_captureFilterSettingsBtn->setIconSize(QSize(15, 15));
+     m_captureFilterSettingsBtn->setToolTip(tr("Options"));
+     m_captureFilterSettingsBtn->setMenu(createOptionsMenu());
+  }
 
   subfolderButton->setObjectName("SubfolderButton");
   subfolderButton->setIconSize(QSize(15, 15));
@@ -1925,6 +1931,7 @@ void PencilTestPopup::onTimeout() { getWebcamImage(); }
 //-----------------------------------------------------------------------------
 
 int PencilTestPopup::translateIndex(int camIndex) {
+#if WIN32
   // We are using Qt to get the camera info and supported resolutions, but
   // we are using OpenCV to actually get the images.
   // The camera index from OpenCV and from Qt don't always agree,
@@ -2000,6 +2007,8 @@ int PencilTestPopup::translateIndex(int camIndex) {
   }
   // clean
   CLEAN_ATTRIBUTES()
+#endif
+    return camIndex;
 }
 
 //-----------------------------------------------------------------------------
@@ -2012,6 +2021,7 @@ void PencilTestPopup::getWebcamImage() {
   if (m_cvWebcam.isOpened() == false) {
     if (m_cameraListCombo->currentIndex() <= 0) return;
     int camIndex = m_cameraListCombo->currentIndex() - 1;
+#if WIN32
     if (!m_useDirectShow) {
       // the webcam order obtained from Qt isn't always the same order as
       // the one obtained from OpenCV without DirectShow
@@ -2019,6 +2029,9 @@ void PencilTestPopup::getWebcamImage() {
     } else {
       m_cvWebcam.open(camIndex, cv::CAP_DSHOW);
     }
+#else
+      m_cvWebcam.open(translateIndex(camIndex));
+#endif
     // mjpg is used by many webcams
     // opencv runs very slow on some webcams without it.
     if (m_useMjpg) {


### PR DESCRIPTION
This PR includes the following changes

- Travis build script changes to install and build using brew installed libjpeg-turbo
- Code changes to fix issues with building without Canon SDK, correct a crash when starting Stop Motion Controls and, correct initialization of webcam
- Updated manual build steps for macOS
