### PR TITLE
Fix linux builds for stopmotion with webcams

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ git:
   depth: 1
   
 sudo: required
-dist: trusty
+dist: xenial
 
 install:
     - bash ci-scripts/$TRAVIS_OS_NAME/travis-install.sh

--- a/ci-scripts/linux/travis-build.sh
+++ b/ci-scripts/linux/travis-build.sh
@@ -3,7 +3,7 @@ pushd thirdparty/tiff-4.0.3
 CFLAGS="-fPIC" CXXFLAGS="-fPIC" ./configure --disable-jbig && make
 popd
 cd toonz && mkdir build && cd build
-source /opt/qt59/bin/qt59-env.sh
+source /opt/qt514/bin/qt514-env.sh
 cmake ../sources \
     -DWITH_SYSTEM_SUPERLU:BOOL=OFF
 # according to https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments

--- a/ci-scripts/linux/travis-install.sh
+++ b/ci-scripts/linux/travis-install.sh
@@ -1,7 +1,8 @@
-sudo add-apt-repository --yes ppa:beineri/opt-qt597-trusty
+sudo add-apt-repository --yes ppa:beineri/opt-qt-5.14.1-xenial
 sudo add-apt-repository --yes ppa:achadwick/mypaint-testing
+sudo add-apt-repository --yes ppa:litenstein/opencv3-xenial
 sudo apt-get update
-sudo apt-get install -y liblzo2-dev liblz4-dev libfreetype6-dev libpng-dev libegl1-mesa-dev libgles2-mesa-dev libglew-dev freeglut3-dev qt59script libsuperlu3-dev qt59svg qt59tools qt59multimedia wget libusb-1.0-0-dev libboost-all-dev liblzma-dev libjson-c-dev libmypaint-dev
+sudo apt-get install -y cmake liblzo2-dev liblz4-dev libfreetype6-dev libpng-dev libegl1-mesa-dev libgles2-mesa-dev libglew-dev freeglut3-dev qt514script libsuperlu-dev qt514svg qt514tools qt514multimedia wget libusb-1.0-0-dev libboost-all-dev liblzma-dev libjson-c-dev libmypaint-dev libjpeg-turbo8-dev libopencv-dev libglib2.0-dev qt514serialport
 
 # someone forgot to include liblz4.pc with the package, use the version from xenial, as it only depends on libc
 wget http://mirrors.kernel.org/ubuntu/pool/main/l/lz4/liblz4-1_0.0~r131-2ubuntu2_amd64.deb -O liblz4.deb

--- a/doc/how_to_build_linux.md
+++ b/doc/how_to_build_linux.md
@@ -13,21 +13,33 @@ Building OpenToonz from source requires the following dependencies:
 - Lzo2
 - FreeType
 - LibMyPaint (1.3 or newer)
+- Jpeg-Turbo (1.4 or newer)
+- OpenCV 3.2 or newer
 
-### Installing Dependencies on Debian / Ubuntu
-
-```
-$ sudo apt-get install build-essential git cmake pkg-config libboost-all-dev qt5-default qtbase5-dev libqt5svg5-dev qtscript5-dev qttools5-dev qttools5-dev-tools libqt5opengl5-dev qtmultimedia5-dev libsuperlu-dev liblz4-dev libusb-1.0-0-dev liblzo2-dev libpng-dev libjpeg-dev libglew-dev freeglut3-dev libfreetype6-dev libjson-c-dev qtwayland5
-```
-
-For newest versions of OS you may install libmypaint from repository and don't need to build it from source:
+### Installing Dependencies on Debian / Ubuntu 16.04 (Xenial)
 
 ```
-$ sudo apt-get install libmypaint-dev
+$ sudo apt-get install build-essential cmake freeglut3-dev libboost-all-dev libegl1-mesa-dev libfreetype6-dev libgles2-mesa-dev libglew-dev libglib2.0-dev libjpeg-dev libjpeg-turbo8-dev libjson-c-dev liblz4-dev liblzma-dev liblzo2-dev libpng-dev libsuperlu-dev libusb-1.0-0-dev pkg-config
+```
+
+Find a PPA respository for Qt 5.9 or later and install the following:
+```
+$ sudo apt-get install -y qt59multimedia qt59script qt59serialport qt59svg qt59tools
+```
+
+Find a PPA repository for MyPaint 1.3 and install the following:
+```
+$ sudo apt-get install -y libmypaint-dev
+```
+
+Find a PPA repository for OpenCV 3.2 or later and install the following:
+```
+$ sudo apt-get install -y libopencv-dev
 ```
 
 Notes:
 * It's possible we also need `libgsl2` (or maybe `libopenblas-dev`)
+* For Qt, MyPaint and OpenCV, you can alternatively build and install from source.
 
 ### Installing Dependencies on Fedora
 (it may include some useless packages)

--- a/toonz/sources/CMakeLists.txt
+++ b/toonz/sources/CMakeLists.txt
@@ -281,10 +281,11 @@ if(BUILD_ENV_MSVC)
     find_package(OpenCV 4.1 REQUIRED
         PATHS "C:/OpenCV/opencv/build" "C:/opencv/build" "C:/Tools/opencv/build"
     )
+elseif(BUILD_ENV_UNIXLIKE)
+    find_package(OpenCV 3.2 REQUIRED)
 else()
     find_package(OpenCV 4.1 REQUIRED)
 endif()
-
 include_directories(
     ${SDKROOT}/libjpeg-turbo64/include
     ${OpenCV_INCLUDE_DIRS}
@@ -490,7 +491,9 @@ elseif(BUILD_ENV_UNIXLIKE)
     endif()
     # Can be 'libmypaint' or 'libmypaint-1.x'
     pkg_search_module(MYPAINT_LIB REQUIRED libmypaint libmypaint-1.3>=1.3)
-    set(TURBOJPEG_LIB ${SDKROOT}/libjpeg-turbo64/lib/turbojpeg.lib)
+
+    find_library(TURBOJPEG_LIB turbojpeg)
+    message("**************** turbojpeg lib:" ${TURBOJPEG_LIB})
 endif()
 
 

--- a/toonz/sources/toonz/penciltestpopup.cpp
+++ b/toonz/sources/toonz/penciltestpopup.cpp
@@ -1282,7 +1282,7 @@ PencilTestPopup::PencilTestPopup()
   m_captureButton          = new QPushButton(tr("Capture\n[Return key]"), this);
   QPushButton* closeButton = new QPushButton(tr("Close"), this);
 
-#if WIN32
+#ifdef WIN32
   m_captureFilterSettingsBtn = new QPushButton(this);
 #else
   m_captureFilterSettingsBtn = 0;
@@ -1931,7 +1931,7 @@ void PencilTestPopup::onTimeout() { getWebcamImage(); }
 //-----------------------------------------------------------------------------
 
 int PencilTestPopup::translateIndex(int camIndex) {
-#if WIN32
+#ifdef WIN32
   // We are using Qt to get the camera info and supported resolutions, but
   // we are using OpenCV to actually get the images.
   // The camera index from OpenCV and from Qt don't always agree,
@@ -2021,7 +2021,7 @@ void PencilTestPopup::getWebcamImage() {
   if (m_cvWebcam.isOpened() == false) {
     if (m_cameraListCombo->currentIndex() <= 0) return;
     int camIndex = m_cameraListCombo->currentIndex() - 1;
-#if WIN32
+#ifdef WIN32
     if (!m_useDirectShow) {
       // the webcam order obtained from Qt isn't always the same order as
       // the one obtained from OpenCV without DirectShow


### PR DESCRIPTION
This PR includes the following changes

- Travis build script changes for installing dependencies and building application
   - Changes build environment to Ubuntu 16.04 (Xenial)
   - Upgraded to use Qt 5.14
   - Uses a minimum of OpenCV 3.2
- Updated manual build steps for Ubuntu/Debian only
- Corrects `#if WIN32` to `#ifdef WIN32`
