### PR TITLE
Revert travis qt version to 5.9

### DIFF
--- a/ci-scripts/linux/travis-build.sh
+++ b/ci-scripts/linux/travis-build.sh
@@ -3,7 +3,7 @@ pushd thirdparty/tiff-4.0.3
 CFLAGS="-fPIC" CXXFLAGS="-fPIC" ./configure --disable-jbig && make
 popd
 cd toonz && mkdir build && cd build
-source /opt/qt514/bin/qt514-env.sh
+source /opt/qt59/bin/qt59-env.sh
 cmake ../sources \
     -DWITH_SYSTEM_SUPERLU:BOOL=OFF
 # according to https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments

--- a/ci-scripts/linux/travis-install.sh
+++ b/ci-scripts/linux/travis-install.sh
@@ -1,8 +1,8 @@
-sudo add-apt-repository --yes ppa:beineri/opt-qt-5.14.1-xenial
+sudo add-apt-repository --yes ppa:beineri/opt-qt597-xenial
 sudo add-apt-repository --yes ppa:achadwick/mypaint-testing
 sudo add-apt-repository --yes ppa:litenstein/opencv3-xenial
 sudo apt-get update
-sudo apt-get install -y cmake liblzo2-dev liblz4-dev libfreetype6-dev libpng-dev libegl1-mesa-dev libgles2-mesa-dev libglew-dev freeglut3-dev qt514script libsuperlu-dev qt514svg qt514tools qt514multimedia wget libusb-1.0-0-dev libboost-all-dev liblzma-dev libjson-c-dev libmypaint-dev libjpeg-turbo8-dev libopencv-dev libglib2.0-dev qt514serialport
+sudo apt-get install -y cmake liblzo2-dev liblz4-dev libfreetype6-dev libpng-dev libegl1-mesa-dev libgles2-mesa-dev libglew-dev freeglut3-dev qt59script libsuperlu-dev qt59svg qt59tools qt59multimedia wget libusb-1.0-0-dev libboost-all-dev liblzma-dev libjson-c-dev libmypaint-dev libjpeg-turbo8-dev libopencv-dev libglib2.0-dev qt59serialport
 
 # someone forgot to include liblz4.pc with the package, use the version from xenial, as it only depends on libc
 wget http://mirrors.kernel.org/ubuntu/pool/main/l/lz4/liblz4-1_0.0~r131-2ubuntu2_amd64.deb -O liblz4.deb


### PR DESCRIPTION
Due to issues with building with QT 5.14, this PR reverts Linux builds back to QT 5.9